### PR TITLE
Allow java plugins to run all tasks not only distribute

### DIFF
--- a/grillplugin/src/main/groovy/com/github/droidpl/android/grillplugin/tasks/GrillPluginExtension.groovy
+++ b/grillplugin/src/main/groovy/com/github/droidpl/android/grillplugin/tasks/GrillPluginExtension.groovy
@@ -137,18 +137,18 @@ public class GrillPluginExtension extends AbstractTaskConfigurer {
         printDebugInfo()
         //Only create those tasks if this is an android project (library or app)
         if (Utils.isAndroidPlugin(project)) {
-            if(qualityTask?.isEnabled()){
-                qualityTask.configureOn(project)
-            }
-            if(documentationTask?.isEnabled()){
-                documentationTask.configureOn(project)
-            }
-            if(testingTask?.isEnabled()){
-                testingTask.configureOn(project)
-            }
             if(googlePlayPublishTask?.isEnabled()){
                 googlePlayPublishTask.configureOn(project)
             }
+        }
+        if(qualityTask?.isEnabled()){
+            qualityTask.configureOn(project)
+        }
+        if(documentationTask?.isEnabled()){
+            documentationTask.configureOn(project)
+        }
+        if(testingTask?.isEnabled()){
+            testingTask.configureOn(project)
         }
         if(distributionTask?.isEnabled()){
             distributionTask.configureOn(project)


### PR DESCRIPTION
We should use all task on a non-android plugin like distributionTask. It will remain googlePlayPublishTask on android only projects. Is it possible to merge?